### PR TITLE
New Feature: Add Token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyc
 *.csv
 *.sqlite
+
+env.sh

--- a/README.md
+++ b/README.md
@@ -27,3 +27,19 @@ $ pip install git+git://github.com/NuCivic/pydkan.git@0.3#egg=pydkan
 [true]
 ```
 Check the examples folder, there are snippets for pretty much everything you can do with this library.
+
+## New Feature: TOKEN
+
+Now it is possible to use a token instead of a user+password combination.
+In order to do that, you need to miss the password argument, and the user
+argument will be understood as a token.
+
+_Everything else works the same_
+
+```python
+>>> from dkan.client import DatasetAPI
+>>> token = '123456789'
+>>> uri = "http://docker:32770"
+>>> api = DatasetAPI(uri, token)
+...
+```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Check the examples folder, there are snippets for pretty much everything you can
 ## New Feature: TOKEN
 
 Now it is possible to use a token instead of a user+password combination.
-In order to do that, you need to miss the password argument, and the user
+In order to do that, you need to omit the password argument, and the user
 argument will be understood as a token.
 
 _Everything else works the same_

--- a/dkan/client.py
+++ b/dkan/client.py
@@ -34,19 +34,22 @@ class DatasetAPI:
     >>> user, password = ('admin', 'admin')
     >>> api = DatasetAPI(uri, user, password)
   """
-  def __init__(self, dkan, user, password, debug=False):
+  def __init__(self, dkan, token, debug=False):
     self.dkan = dkan
     self.headers = {
       'Accept': 'application/json',
     }
+    self.token = {
+        'services_token': token
+        }
     self.cookies = {}
     self.debug = debug
-    self.login(user, password)
+    # self.login(token)
 
   def build_uri(self, path):
     return os.path.join(self.dkan, path).replace('\\', '/')
 
-  def login(self, user, password):
+  def login(self, token):
     """Authenticates against the dkan site.
 
     This method should not be called from user code. It authenticates
@@ -62,8 +65,7 @@ class DatasetAPI:
     """
     uri = self.build_uri('api/dataset/user/login')
     data = {
-      'username': user,
-      'password': password
+        'services_token': token
     }
     # Login and set cookie
     login = self.post(uri, data=data)
@@ -172,7 +174,7 @@ class DatasetAPI:
     files = {
       'files[1]': open(file, 'rb'),
     }
-    return self.post(uri, headers=headers, data=data, files=files)
+    return self.post(uri, headers=headers, data=data, files=files, params=self.token)
 
   @classmethod
   def pretty_print_request(cls, req):
@@ -187,3 +189,15 @@ class DatasetAPI:
         req.body,
         '------------END------------'
     ))
+
+"""
+http://massdocsdev.prod.acquia-sites.com
+
+curl -v -H "Content-Type: application/json" -X PUT -d "{\"title\":\"Title Updated by SS\"}" "http://docs.digital.mass.gov//api/action/datastore/node/1046?services_token=e403b17c91d45dd686506aa006b1b0b243854341" -H 'cache-control: no-cache'
+
+# Not working
+curl -v -H "Content-Type: application/json" -X PUT -d "{\"title\":\"Title SLESLESLE\"}" "http://massdocsdev.prod.acquia-sites.com//api/action/datastore/node/1046?services_token=e403b17c91d45dd686506aa006b1b0b243854341" -H 'cache-control: no-cache'
+
+curl -v -H "Content-Type: application/json" -X PUT -d "{\"title\":\"Title SLESLESLE\"}" "http://massgov:for the commonwealth@massdocsdev.prod.acquia-sites.com//api/action/datastore/node/1046?services_token=e403b17c91d45dd686506aa006b1b0b243854341" -H 'cache-control: no-cache'
+
+"""

--- a/dkan/client.py
+++ b/dkan/client.py
@@ -189,15 +189,3 @@ class DatasetAPI:
         req.body,
         '------------END------------'
     ))
-
-"""
-http://massdocsdev.prod.acquia-sites.com
-
-curl -v -H "Content-Type: application/json" -X PUT -d "{\"title\":\"Title Updated by SS\"}" "http://docs.digital.mass.gov//api/action/datastore/node/1046?services_token=e403b17c91d45dd686506aa006b1b0b243854341" -H 'cache-control: no-cache'
-
-# Not working
-curl -v -H "Content-Type: application/json" -X PUT -d "{\"title\":\"Title SLESLESLE\"}" "http://massdocsdev.prod.acquia-sites.com//api/action/datastore/node/1046?services_token=e403b17c91d45dd686506aa006b1b0b243854341" -H 'cache-control: no-cache'
-
-curl -v -H "Content-Type: application/json" -X PUT -d "{\"title\":\"Title SLESLESLE\"}" "http://massgov:for the commonwealth@massdocsdev.prod.acquia-sites.com//api/action/datastore/node/1046?services_token=e403b17c91d45dd686506aa006b1b0b243854341" -H 'cache-control: no-cache'
-
-"""

--- a/dkan/client.py
+++ b/dkan/client.py
@@ -82,7 +82,7 @@ class DatasetAPI:
       message = 'pydkan client can\'t login.(%s %s)' % (login.status_code, login.content)
       raise LoginError(message)
 
-  def node(self, action='index', **kwargs):
+  def node(self, action='index', params=self.token, **kwargs):
     """Interface to the node endpoint.
 
     This method builds requests against the api/dataset/node endpoint. It is

--- a/examples/attach_file_to_node.py
+++ b/examples/attach_file_to_node.py
@@ -2,22 +2,28 @@ import os
 import json
 from dkan.client import DatasetAPI
 
+#specify your DKAN_URI you are posting to here, e.g. 'http://docs.digital.mass.gov/'
 uri = os.environ.get('DKAN_URI', False)
-user = os.environ.get('DKAN_USER', 'admin')
-password = os.environ.get('DKAN_PASSWORD', 'admin')
+# user = os.environ.get('DKAN_USER', 'admin')
+# password = os.environ.get('DKAN_PASSWORD', 'admin')
+token = "put your service token here"
 
 if uri:
-  api = DatasetAPI(uri, user, password, True)
+  #api = DatasetAPI(uri, user, password, True)
+  api = DatasetAPI(uri, token, True)
   payload = {'parameters[type]': 'resource'}
   nodes = api.node(params=payload).json()
   resource = nodes[0]
   print resource
-  csv = os.path.join(os.path.dirname(os.path.abspath(__file__)), '.',
-                     'data', 'tension_sample_data.csv')
+  #csv = os.path.join(os.path.dirname(os.path.abspath(__file__)), '.',
+  #                   'data', 'tension_sample_data.csv')
+  #specify the file you want to post to the resource node you are updating here.
+  csv = full_path = os.path.expanduser('~/Downloads/sample_test_data.csv')
   # Attach the file to the resource node
   r = api.attach_file_to_node(csv, resource['nid'], 'field_upload')
   print r.status_code
   print r. text
+  #specify the node id of the resource/item you are posting to, e.g. 'node_id=771'
   resource = api.node('retrieve', node_id=resource['nid'])
   print resource.json()['field_upload']
 else:

--- a/examples/attach_file_to_node.py
+++ b/examples/attach_file_to_node.py
@@ -5,9 +5,11 @@ from dkan.client import DatasetAPI
 uri = os.environ.get('DKAN_URI', False)
 user = os.environ.get('DKAN_USER', 'admin')
 password = os.environ.get('DKAN_PASSWORD', 'admin')
+token = os.environ.get('TOKEN')
 
 if uri:
-  api = DatasetAPI(uri, user, password, True)
+  # api = DatasetAPI(uri, user, password, True)
+  api = DatasetAPI(uri, token)
   payload = {'parameters[type]': 'resource'}
   nodes = api.node(params=payload).json()
   resource = nodes[0]

--- a/examples/attach_file_to_node.py
+++ b/examples/attach_file_to_node.py
@@ -2,29 +2,23 @@ import os
 import json
 from dkan.client import DatasetAPI
 
-#specify your DKAN_URI you are posting to here, e.g. 'http://docs.digital.mass.gov/'
 uri = os.environ.get('DKAN_URI', False)
-# user = os.environ.get('DKAN_USER', 'admin')
-# password = os.environ.get('DKAN_PASSWORD', 'admin')
-token = "put your service token here"
+user = os.environ.get('DKAN_USER', 'admin')
+password = os.environ.get('DKAN_PASSWORD', 'admin')
 
 if uri:
-  #api = DatasetAPI(uri, user, password, True)
-  api = DatasetAPI(uri, token, True)
+  api = DatasetAPI(uri, user, password, True)
   payload = {'parameters[type]': 'resource'}
   nodes = api.node(params=payload).json()
   resource = nodes[0]
   print resource
-  #csv = os.path.join(os.path.dirname(os.path.abspath(__file__)), '.',
-  #                   'data', 'tension_sample_data.csv')
-  #specify the file you want to post to the resource node you are updating here.
-  csv = full_path = os.path.expanduser('~/Downloads/sample_test_data.csv')
+  csv = os.path.join(os.path.dirname(os.path.abspath(__file__)), '.',
+                     'data', 'tension_sample_data.csv')
   # Attach the file to the resource node
   r = api.attach_file_to_node(csv, resource['nid'], 'field_upload')
   print r.status_code
   print r. text
-  #specify the node id of the resource/item you are posting to, e.g. 'node_id=771'
   resource = api.node('retrieve', node_id=resource['nid'])
   print resource.json()['field_upload']
 else:
-  print 'Please Set the dkan URL as an ENVIRONMENT variable'  
+  print 'Please Set the dkan URL as an ENVIRONMENT variable'

--- a/examples/create_node.py
+++ b/examples/create_node.py
@@ -5,11 +5,14 @@ from dkan.client import DatasetAPI
 uri = os.environ.get('DKAN_URI', False)
 user = os.environ.get('DKAN_USER', 'admin')
 password = os.environ.get('DKAN_PASSWORD', 'admin')
+token = os.environ.get('TOKEN')
+
+print uri, token
 
 if uri:
-  api = DatasetAPI(uri, user, password, True)
+  api = DatasetAPI(uri, token)
   data = {
-      'title': 'Test Dataset',
+      'title': 'Test Dataset SLE 1',
       'type': 'dataset'
   }
   dataset = api.node('create', data=data)

--- a/examples/create_node.py
+++ b/examples/create_node.py
@@ -12,7 +12,7 @@ print uri, token
 if uri:
   api = DatasetAPI(uri, token)
   data = {
-      'title': 'Test Dataset SLE 1',
+      'title': 'Test Dataset',
       'type': 'dataset'
   }
   dataset = api.node('create', data=data)

--- a/examples/delete_node.py
+++ b/examples/delete_node.py
@@ -5,9 +5,11 @@ from dkan.client import DatasetAPI
 uri = os.environ.get('DKAN_URI', False)
 user = os.environ.get('DKAN_USER', 'admin')
 password = os.environ.get('DKAN_PASSWORD', 'admin')
+token = os.environ.get('TOKEN')
 
 if uri:
-  api = DatasetAPI(uri, user, password, True)
+  # api = DatasetAPI(uri, user, password, True)
+  api = DatasetAPI(uri, token)
   data = {
       'title': 'Test Dataset',
       'type': 'dataset'

--- a/examples/full_crud.py
+++ b/examples/full_crud.py
@@ -5,9 +5,11 @@ from client import DatasetAPI
 uri = os.environ.get('DKAN_URI', False)
 user = os.environ.get('DKAN_USER', 'admin')
 password = os.environ.get('DKAN_PASSWORD', 'admin')
+token = os.environ.get('TOKEN')
 
 if uri:
-    api = DatasetAPI(uri, user, password, True)
+    # api = DatasetAPI(uri, user, password, True)
+    api = DatasetAPI(uri, token)
     # Create dataset
     print 'CREATE DATASET'
     data = {
@@ -26,7 +28,7 @@ if uri:
             'und': {
                 'target_id': dataset_nid,
             },
-            
+
         },
     }
     r = api.node('create', data=data)

--- a/examples/list_nodes.py
+++ b/examples/list_nodes.py
@@ -5,10 +5,12 @@ from dkan.client import DatasetAPI
 uri = os.environ.get('DKAN_URI', False)
 user = os.environ.get('DKAN_USER', 'admin')
 password = os.environ.get('DKAN_PASSWORD', 'admin')
+token = os.environ.get('TOKEN')
 
 if uri:
   # Make the api authenticate properly
-  api = DatasetAPI(uri, user, password, True)
+  # api = DatasetAPI(uri, user, password, True)
+  api = DatasetAPI(uri, token)
 
   # List datasets
   params = {

--- a/examples/update_node.py
+++ b/examples/update_node.py
@@ -3,25 +3,22 @@ import json
 from dkan.client import DatasetAPI
 
 uri = os.environ.get('DKAN_URI', False)
-#user = os.environ.get('DKAN_USER', 'admin')
-#password = os.environ.get('DKAN_PASSWORD', 'admin')
-token = 'put your services token here'
+user = os.environ.get('DKAN_USER', 'admin')
+password = os.environ.get('DKAN_PASSWORD', 'admin')
 
 if uri:
-  #api = DatasetAPI(uri, user, password, True)
-  api = DatasetAPI(uri, token, True)
-  #data = {
-  #    'title': 'Test Dataset',
-  #    'type': 'dataset'
-  #}
-  #dataset = api.node('create', data=data)
-  #print dataset.status_code
-  #print dataset.text
-  #dataset = dataset.json()
+  api = DatasetAPI(uri, user, password, True)
+  data = {
+      'title': 'Test Dataset',
+      'type': 'dataset'
+  }
+  dataset = api.node('create', data=data)
+  print dataset.status_code
+  print dataset.text
+  dataset = dataset.json()
   update = {
     'title': 'Test Dataset Updated',
   }
-  #change the node_id to the dataset node id that you want to update, e.g. node_id=1041
   r = api.node('update', node_id=dataset['nid'], data=update)
   print r.status_code
   print r.text

--- a/examples/update_node.py
+++ b/examples/update_node.py
@@ -5,9 +5,11 @@ from dkan.client import DatasetAPI
 uri = os.environ.get('DKAN_URI', False)
 user = os.environ.get('DKAN_USER', 'admin')
 password = os.environ.get('DKAN_PASSWORD', 'admin')
+token = os.environ.get('TOKEN')
 
 if uri:
-  api = DatasetAPI(uri, user, password, True)
+  # api = DatasetAPI(uri, user, password, True)
+  api = DatasetAPI(uri, token)
   data = {
       'title': 'Test Dataset',
       'type': 'dataset'

--- a/examples/update_node.py
+++ b/examples/update_node.py
@@ -3,22 +3,25 @@ import json
 from dkan.client import DatasetAPI
 
 uri = os.environ.get('DKAN_URI', False)
-user = os.environ.get('DKAN_USER', 'admin')
-password = os.environ.get('DKAN_PASSWORD', 'admin')
+#user = os.environ.get('DKAN_USER', 'admin')
+#password = os.environ.get('DKAN_PASSWORD', 'admin')
+token = 'put your services token here'
 
 if uri:
-  api = DatasetAPI(uri, user, password, True)
-  data = {
-      'title': 'Test Dataset',
-      'type': 'dataset'
-  }
-  dataset = api.node('create', data=data)
-  print dataset.status_code
-  print dataset.text
-  dataset = dataset.json()
+  #api = DatasetAPI(uri, user, password, True)
+  api = DatasetAPI(uri, token, True)
+  #data = {
+  #    'title': 'Test Dataset',
+  #    'type': 'dataset'
+  #}
+  #dataset = api.node('create', data=data)
+  #print dataset.status_code
+  #print dataset.text
+  #dataset = dataset.json()
   update = {
     'title': 'Test Dataset Updated',
   }
+  #change the node_id to the dataset node id that you want to update, e.g. node_id=1041
   r = api.node('update', node_id=dataset['nid'], data=update)
   print r.status_code
   print r.text

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='pydkan',
-    version='0.1',
+    version='0.1.1',
     author=u'NuCivic',
     author_email='devops@nucivic.com',
     license='BSD licence, see LICENCE.txt',


### PR DESCRIPTION
This Pull Request adds a new functionality to the **pydkan** package: the ability to not only use `username/password` but also `tokens`.

_The Good_ 
- There is no difference in the way we use this package at all. Only at the beginning, when creating the instance, instead of using `api = DatasetAPI(uri, user, password)` we do `api = DatasetAPI(uri, token)` assuming `token` has already being defined.
- There were very small changes in some functions to allow this to work, but not on the "user space". The functionality is the same.
- The examples has been updated to use `tokens`.
- The `README` has been updated.

_The Bad_
- There is one thing that could break this implementation. Doing `api = DatasetAPI(uri, token, True)`. If using `token` and want to set debug to `True` the way to do that is `api = DatasetAPI(uri, token, debug=True)`.
- There is no `token` argument (at least with that name), so `api = DatasetAPI(uri, token=token, debug=True)` won't work. 

_The Missing_
- I haven't updated the tests. If this PR gets accepted, I will definitely do that (and make another PR).